### PR TITLE
ed8pkg2gltf.py: add support for relative source and destination path

### DIFF
--- a/ed8pkg2gltf.py
+++ b/ed8pkg2gltf.py
@@ -3756,7 +3756,7 @@ def process_pkg(pkg_name, partialmaps = partial_vgmaps_default, allbuffers = Fal
             if not os.path.exists(dest_dir):
                 os.makedirs(dest_dir, exist_ok=True)
             allowed_write_extensions = ['.glb', '.json', '.dds', '.xml', '.phyre']
-            storage_media = TSpecialOverlayMedia(os.path.realpath(pkg_name),  allowed_write_extensions)
+            storage_media = TSpecialOverlayMedia(os.path.realpath(pkg_name), allowed_write_extensions)
             items = []
 
             def list_callback(item):


### PR DESCRIPTION
Before this commit all path were relative to the script location which
make sense when you execute the script from the windows explorer but
doesn't work well with relative path when executed from the command line
because it makes all path be relative to the script location not the
working directory of the interpreter.
Now the working directory is only changed to the script location if
there are no command line arguments.