### PR TITLE
build_collada.py: make RunMe.bat fail if any of sub commands fail

### DIFF
--- a/build_collada.py
+++ b/build_collada.py
@@ -1176,6 +1176,12 @@ class ShellScriptBuilder:
     def run_exe(self, cmd_line):
         if self.windows:
             self.buffer += cmd_line + "\r\n"
+            self.buffer += '''if %ERRORLEVEL% NEQ 0 (
+    echo command failed: {}
+    pause
+    goto :EOF
+)
+'''.format(cmd_line)
         else:
             # wine is quite verbose. discard output.
             self.buffer += "wine " + cmd_line + " &> /dev/null\n"


### PR DESCRIPTION
In case any of the sub commands fails it usually doesn't make sense to continue and by providing an explicit error message and stopping it is easier to debug this.